### PR TITLE
content: FAQ回答と差別化アイコンを更新

### DIFF
--- a/index.html
+++ b/index.html
@@ -236,7 +236,7 @@
           "name": "AI開発の費用はいくらから始められますか？",
           "acceptedAnswer": {
             "@type": "Answer",
-            "text": "プロトタイプ開発は30万円からご利用いただけます。段階的投資により初期費用を抑え、効果を確認しながら本格開発に進むことで確実なROIを実現します。具体的な費用は、プロジェクトの規模や内容によって異なりますので、無料相談でお気軽にお問い合わせください。"
+            "text": "段階的投資により初期費用を抑え、効果を確認しながら本格開発に進むことで確実なROIを実現します。具体的な費用は、プロジェクトの規模や内容によって異なりますので、無料相談でお気軽にお問い合わせください。"
           }
         },
         {
@@ -260,7 +260,7 @@
           "name": "AIエージェント開発ではどのような技術を使用しますか？",
           "acceptedAnswer": {
             "@type": "Answer",
-            "text": "ChatGPT/GPT-4などのLLM（大規模言語モデル）を活用し、お客様の業務フローに最適化したAIエージェントを構築します。また、RAG（Retrieval Augmented Generation）技術により社内データを効率的に活用し、ベクトルデータベースを用いた高度なシステム構築も可能です。"
+            "text": "最新のLLM（大規模言語モデル）やAPI連携を活用し、お客様の業務フローに最適化したAIエージェントを構築します。RAG（Retrieval Augmented Generation）技術による社内データの効率的活用、MCPサーバー構築によるワークフロー最適化、ベクトルデータベースを用いた高度なシステム構築など、包括的なAIソリューションを提供します。"
           }
         }
       ]
@@ -2643,7 +2643,7 @@
                     <div class="hero-differentiators">
                         <div class="differentiator-item">
                             <div class="differentiator-icon">
-                                <i class="fas fa-rocket"></i>
+                                <i class="fas fa-seedling"></i>
                             </div>
                             <h3 class="differentiator-title">小さく始める</h3>
                             <p class="differentiator-text-pc">
@@ -2927,7 +2927,7 @@
                     
                     <div class="faq-item">
                         <h3 class="faq-question">Q: AI開発の費用はいくらから始められますか？</h3>
-                        <p class="faq-answer">A: プロトタイプ開発は30万円からご利用いただけます。段階的投資により初期費用を抑え、効果を確認しながら本格開発に進むことで確実なROIを実現します。具体的な費用は、プロジェクトの規模や内容によって異なりますので、無料相談でお気軽にお問い合わせください。</p>
+                        <p class="faq-answer">A: 段階的投資により初期費用を抑え、効果を確認しながら本格開発に進むことで確実なROIを実現します。具体的な費用は、プロジェクトの規模や内容によって異なりますので、無料相談でお気軽にお問い合わせください。</p>
                     </div>
                     
                     <div class="faq-item">
@@ -2942,7 +2942,7 @@
                     
                     <div class="faq-item">
                         <h3 class="faq-question">Q: AIエージェント開発ではどのような技術を使用しますか？</h3>
-                        <p class="faq-answer">A: ChatGPT/GPT-4などのLLM（大規模言語モデル）を活用し、お客様の業務フローに最適化したAIエージェントを構築します。また、RAG（Retrieval Augmented Generation）技術により社内データを効率的に活用し、ベクトルデータベースを用いた高度なシステム構築も可能です。</p>
+                        <p class="faq-answer">A: 最新のLLM（大規模言語モデル）やAPI連携を活用し、お客様の業務フローに最適化したAIエージェントを構築します。RAG（Retrieval Augmented Generation）技術による社内データの効率的活用、MCPサーバー構築によるワークフロー最適化、ベクトルデータベースを用いた高度なシステム構築など、包括的なAIソリューションを提供します。</p>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
## 変更内容

- 「小さく始める」セクションのアイコンを `fa-rocket` から `fa-seedling` に変更
- FAQ費用回答から具体的な金額表記（30万円から）を削除
- FAQ技術回答を更新:
  - 「ChatGPT/GPT-4などのLLM」→「最新のLLM」に汎用化
  - 「MCPサーバー構築によるワークフロー最適化」を追加
- 構造化データ（JSON-LD）の該当箇所も同様に更新

## 関連コミット
https://github.com/shin-ai-inc/website/commit/8358c11cf3b4e567c5184aee0c029383b0d6d5aa