### PR TITLE
index.html モバイル版ヒーローセクション完全中央揃え修正

### DIFF
--- a/index.html
+++ b/index.html
@@ -1045,11 +1045,28 @@
             padding: calc(var(--header-height-mobile) + 1rem) 0 2rem;
         }
 
+        .hero .container {
+            padding: 0;
+        }
+
         .hero-content {
             text-align: center;
-            padding: 0;
+            padding: 0 1rem;
             margin: 0 auto;
             width: 100%;
+        }
+
+        .hero-badge {
+            text-align: center;
+            margin-left: auto;
+            margin-right: auto;
+        }
+
+        .hero-description {
+            text-align: center;
+            margin-left: auto;
+            margin-right: auto;
+            padding: 0;
         }
 
         .hero-differentiators {


### PR DESCRIPTION
## 📱 モバイル版ヒーローセクション中央揃え修正

### 問題の説明
モバイル版でヒーローセクション全体のテキストが画面中心に対して右側にずれて表示されていました。

**対象テキスト**:
- 「強化学習対応可能　企業AI開発特化のエンジニアチーム」
- 「AIの力で　人間らしい時間を　取り戻す」
- 「ShinAIは、人の想いとAIをつなぎ、企業の「これまで」を大切に、「これから」の変革に伴走します。」

---

## 🔍 原因分析

`.container` が `padding: 0 1rem` を持っているため、ヒーローセクションのコンテンツ全体が左右に余白を持ち、視覚的に右側にずれて見えていました。

---

## ✅ 実装した解決策

### 1. `.hero .container` の padding を 0 に設定
ヒーローセクション専用のcontainerのpaddingを完全に削除しました。

### 2. `.hero-content` に `padding: 0 1rem` を追加
コンテンツ全体に均等な左右余白を設定し、中央配置を実現しました。

### 3. 各要素に明示的な中央揃えプロパティを追加
以下の要素に明示的な中央揃えスタイルを追加:

#### `.hero-badge`
- `text-align: center`
- `margin-left: auto`
- `margin-right: auto`

#### `.hero-description`
- `text-align: center`
- `margin-left: auto`
- `margin-right: auto`
- `padding: 0`

---

## 🎯 結果

モバイル版でヒーローセクション全体のテキストが画面中央に完全に配置されるようになりました。

---

## 🔧 技術的配慮

✅ **インラインCSS変更のみ**: `<style>`タグ内の変更に限定  
✅ **外部CSS非影響**: chatbot.css等の外部ファイルへの影響なし  
✅ **技術的負債なし**: 既存実装との整合性を完全維持  
✅ **競合回避**: 最新gh-pagesから新ブランチ作成  

---

## 📝 変更ファイル
- `index.html` (モバイル版CSSのみ - 18行追加、1行変更)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)