### PR TITLE
index.html ヒーローセクションdifferentiators プロフェッショナルレイアウト改善

### DIFF
--- a/index.html
+++ b/index.html
@@ -887,14 +887,14 @@
     }
     
     /* ========================================================
-    ▼ Hero Differentiators Component - masa様要求: 均等な余白バランス + 地球型エフェクト中心整列
+    ▼ Hero Differentiators Component - プロフェッショナル均等配置
     ======================================================== */
     .hero-differentiators {
-        display: flex;
-        justify-content: space-between;
-        align-items: center;
+        display: grid;
+        grid-template-columns: repeat(3, 1fr);
+        gap: 3rem;
         margin: 3rem auto 3.5rem;
-        max-width: 1100px;
+        max-width: 1200px;
         width: 100%;
         padding: 0 2rem;
         animation: fadeInUp 0.5s ease 0.3s forwards;
@@ -907,29 +907,10 @@
         flex-direction: column;
         align-items: center;
         justify-content: flex-start;
-        flex: 0 0 280px;
         position: relative;
         z-index: 10;
         cursor: pointer;
-    }
-
-    /* 中央要素(伴走型支援)を地球型エフェクトの中心に完全整列 */
-    .differentiator-item:nth-child(2) {
-        position: absolute;
-        left: 50%;
-        transform: translateX(-50%);
-        z-index: 15;
-    }
-
-    /* 左要素(暗黙知のデータ化) - 左余白確保 */
-    .differentiator-item:nth-child(1) {
-        margin-left: 0;
-    }
-
-    /* 右要素(パートナーシップ) - 右余白確保 */
-    .differentiator-item:nth-child(3) {
-        margin-right: 0;
-        margin-left: auto;
+        padding: 0 1rem;
     }
 
     .differentiator-icon {
@@ -1070,51 +1051,35 @@
         }
 
         .hero-differentiators {
-            display: flex;
-            flex-direction: row;
-            justify-content: space-between;
-            gap: 0.6rem;
-            margin: 2.5rem auto 3rem;
+            display: grid;
+            grid-template-columns: 1fr;
+            gap: 1.5rem;
+            margin: 2rem auto 2.5rem;
             padding: 0 1rem;
-            max-width: 100%;
+            max-width: 400px;
         }
 
         .differentiator-item {
-            flex: 0 0 110px;
-            max-width: 110px;
-            min-width: 110px;
             background: rgba(255, 255, 255, 0.08);
-            padding: 0.9rem 0.4rem;
-            border-radius: 10px;
+            padding: 1.5rem 1.2rem;
+            border-radius: 12px;
             box-shadow: 0 4px 20px rgba(58, 95, 235, 0.12),
                         0 0 0 1px rgba(255, 255, 255, 0.08);
             backdrop-filter: blur(10px);
             -webkit-backdrop-filter: blur(10px);
             border: 1px solid rgba(255, 255, 255, 0.15);
         }
-
-        /* モバイルでは中央要素も通常配置 */
-        .differentiator-item:nth-child(2) {
-            position: static;
-            transform: none;
-            margin: 0;
-        }
-
-        .differentiator-item:nth-child(1),
-        .differentiator-item:nth-child(3) {
-            margin: 0;
-        }
         
         .differentiator-icon {
-            width: 36px;
-            height: 36px;
-            font-size: 1rem;
-            margin-bottom: 0.5rem;
-            border-radius: 8px;
+            width: 56px;
+            height: 56px;
+            font-size: 1.5rem;
+            margin-bottom: 1rem;
+            border-radius: 12px;
             background: rgba(255, 255, 255, 0.08);
             border: 1px solid rgba(255, 255, 255, 0.15);
         }
-        
+
         .differentiator-item:active .differentiator-icon {
             background: var(--differentiator-bg-hover);
             color: var(--differentiator-icon-hover);
@@ -1123,21 +1088,21 @@
             backdrop-filter: blur(12px);
             -webkit-backdrop-filter: blur(12px);
         }
-        
+
         .differentiator-title {
-            font-size: 0.8rem;
-            margin-bottom: 0.4rem;
-            line-height: 1.1;
+            font-size: 1.05rem;
+            margin-bottom: 0.8rem;
+            line-height: 1.3;
             font-weight: var(--font-weight-extrabold);
         }
-        
+
         .differentiator-text-pc {
             display: none;
         }
-        
+
         .differentiator-text-mobile {
             display: block;
-            font-size: 0.65rem;
+            font-size: 0.9rem;
             line-height: 1.3;
         }
         


### PR DESCRIPTION
## 🎨 ヒーローセクションdifferentiators プロフェッショナルレイアウト改善

### 改善概要
PC版とモバイル版の両方で、「暗黙知のデータ化」「伴走型支援」「パートナーシップ」の3つのdifferentiator項目のレイアウトをプロフェッショナルに改善しました。

---

## 🖥️ PC版改善内容

### Before（問題点）
- **flexbox + position: absolute**: 複雑な配置ロジック
- **max-width: 1100px**: 狭すぎて窮屈
- **中央要素が絶対配置**: 他の要素と重なりやすく、バランスが悪い
- **3つの要素が中央に集約**: 見栄えが悪い

### After（プロフェッショナル改善）
✅ **CSS Grid採用**: `grid-template-columns: repeat(3, 1fr)`で均等配置  
✅ **max-width: 1200px**: 適度な広さを確保  
✅ **gap: 3rem**: 要素間に十分な余白  
✅ **シンプルな配置ロジック**: position: absoluteを完全排除  

**結果**: 3つの要素が画面全体に均等配置され、プロフェッショナルでバランスの良いレイアウトを実現

---

## 📱 モバイル版改善内容

### Before（問題点）
- **横並び3列**: 110px幅で非常に狭い
- **テキストがほぼ読めない**: font-size: 0.65rem
- **アイコンが小さすぎる**: 36px × 36px
- **実質非表示状態**: ユーザビリティが著しく低い

### After（スマート表示）
✅ **縦並び1列レイアウト**: `grid-template-columns: 1fr`  
✅ **カード型デザイン採用**:
- `padding: 1.5rem 1.2rem`（読みやすい余白）
- `border-radius: 12px`（モダンな角丸）
- 背景: `rgba(255, 255, 255, 0.08)`（ガラスモーフィズム）
- `backdrop-filter: blur(10px)`（美しいブラー効果）

✅ **視認性大幅向上**:
- **アイコン**: 56px × 56px（36px → 56px: 56%拡大）
- **タイトル**: 1.05rem（0.8rem → 1.05rem: 31%拡大）
- **テキスト**: 0.9rem（0.65rem → 0.9rem: 38%拡大）

✅ **レイアウト最適化**:
- `gap: 1.5rem`（カード間の適切な余白）
- `max-width: 400px`（モバイル最適幅）

**結果**: 縦並びカードレイアウトでスマートに表示され、すべての情報が読みやすく美しく表示される

---

## 📊 改善効果まとめ

### PC版
✅ プロフェッショナルな均等配置  
✅ バランスの良いレイアウト  
✅ シンプルで保守性の高いコード  

### モバイル版
✅ ユーザビリティ大幅向上  
✅ 視認性・可読性の劇的改善  
✅ モダンなカードデザイン  

### コード品質
✅ CSS Gridによるシンプルな実装  
✅ 保守性の高いコード  
✅ レスポンシブデザインのベストプラクティス適用  

---

## 🔧 技術的配慮

✅ **インラインCSS変更のみ**: `<style>`タグ内の変更に限定  
✅ **外部CSS非影響**: chatbot.css等の外部ファイルへの影響なし  
✅ **技術的負債なし**: 既存実装との整合性を完全維持  
✅ **競合回避**: 最新gh-pagesから新ブランチ作成  
✅ **60行削減**: position: absolute等の複雑なコードを削除  

---

## 📝 変更ファイル
- `index.html` (26行追加、61行削除、純減35行)

---

## 🎯 期待される効果
- **PC版**: プロフェッショナルな印象・視覚的バランスの向上
- **モバイル版**: ユーザビリティ・視認性の劇的改善
- **全体**: ブランドイメージの向上・コンバージョン率改善

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)