### PR TITLE
サービスカード間隔最適化・モバイルチャットボットUX完全刷新

### DIFF
--- a/assets/css/chatbot.css
+++ b/assets/css/chatbot.css
@@ -449,26 +449,27 @@ AUTHOR: ShinAI Development Team
         font-size: 1.2rem;
     }
 
-    /* モバイル版チャットボット最適化 - フルスクリーン表示 */
+    /* モバイル版チャットボット最適化 - 既存ページ背景視認可能 */
     .chatbot-window {
         position: fixed;
-        top: 0;
+        top: 10%;
         right: 0;
         left: 0;
         bottom: 0;
         width: 100%;
         max-width: 100%;
-        height: 100vh;
-        max-height: 100vh;
-        border-radius: 0;
-        transform-origin: center;
-        box-shadow: none;
+        height: 90vh;
+        max-height: 90vh;
+        border-radius: 20px 20px 0 0;
+        transform-origin: bottom center;
+        box-shadow: 0 -4px 20px rgba(0, 0, 0, 0.15);
         margin: 0;
+        background: var(--white);
     }
 
     .chatbot-header {
         padding: 1rem 1.2rem;
-        border-radius: 0;
+        border-radius: 20px 20px 0 0;
     }
 
     .chatbot-header h3 {

--- a/index.html
+++ b/index.html
@@ -1130,8 +1130,8 @@
     .services-grid {
         display: grid;
         grid-template-columns: repeat(3, 1fr);
-        gap: 2.5rem;
-        max-width: 1200px;
+        gap: 1.2rem;
+        max-width: 950px;
         margin: 0 auto;
     }
     
@@ -1293,8 +1293,8 @@
     @media (max-width: 992px) {
         .services-grid {
             grid-template-columns: repeat(3, 1fr);
-            gap: 1.5rem;
-            max-width: 900px;
+            gap: 1rem;
+            max-width: 800px;
         }
         
         .service-card {
@@ -1313,7 +1313,7 @@
     @media (max-width: 768px) {
         .services-grid {
             grid-template-columns: 1fr;
-            gap: 1.5rem;
+            gap: 1.2rem;
             max-width: 320px;
         }
         
@@ -2742,11 +2742,17 @@
         if (chatbotButton && chatbotWindow && chatbotClose) {
             chatbotButton.addEventListener('click', function() {
                 chatbotWindow.classList.toggle('active');
-                
+
                 const expanded = this.getAttribute('aria-expanded') === 'true';
                 this.setAttribute('aria-expanded', !expanded);
-                
-                if (!expanded) {
+
+                // モバイルでは入力欄を最初はreadonly、タップ時のみキーボード表示
+                if (!expanded && window.innerWidth <= 768) {
+                    chatInput.setAttribute('readonly', 'true');
+                    setTimeout(() => {
+                        chatInput.removeAttribute('readonly');
+                    }, 100);
+                } else if (!expanded) {
                     chatInput.focus();
                 }
             });


### PR DESCRIPTION
## 変更内容

### 1. サービスカード間隔調整 - 色気復活

**問題点**: 
- 初回修正で余白が大きすぎて色気が失われた
- 前回のサイズ感が良かった

**改善内容**:

| 画面サイズ | 初回修正(過大) | 最終調整(適切) |
|----------|--------------|--------------|
| PC (>992px) | 2.5rem (40px) | **1.2rem (19.2px)** |
| タブレット (≤992px) | 1.5rem (24px) | **1rem (16px)** |
| モバイル (≤768px) | 1.5rem (24px) | **1.2rem (19.2px)** |

**デザイン改善**:
- 視覚的呼吸感と色気のバランス最適化
- max-width調整: PC 1200px→950px, タブレット 900px→800px
- 各カードの独立性を保ちつつ、視覚的統一感を強化

---

### 2. モバイル版チャットボットUX完全刷新

**問題点** (CRITICAL):
- フルスクリーン仕様では既存ページが完全に隠れる
- チャット展開時に即座にキーボードが表示され、メッセージエリアが見えない
- ユーザー体験として不自然

**改善内容**:

**既存ページ背景視認可能**:
- top: 10%, height: 90vh - 上部10%は既存ページ背景が見える
- border-radius: 20px 20px 0 0 - 上部丸角で浮き上がる演出
- box-shadow: 0 -4px 20px - 上向きシャドウで立体感

**段階的キーボード表示**:
- チャットボタンタップ → ウィンドウ展開（キーボード非表示）
- ヘッダー・メッセージエリア・入力欄すべて視認可能
- 入力欄タップ時のみキーボード表示（readonly制御）

**全ページ対応**:
- index.html, about.html, services.html, industries.html, contact.html, faq.html
- 外部CSS (assets/css/chatbot.css) 修正により全ページ一括適用

**UX改善効果**:
1. 既存ページとの視覚的連続性維持
2. チャット内容を確認してから入力可能
3. ネイティブアプリ相当の自然なUX実現

---

## 検証方法

1. PC・タブレット・モバイルでサービスカード間隔が適切になっていることを確認
2. モバイルでチャットボタンタップ時、上部10%に既存ページ背景が見えることを確認
3. チャット展開直後はキーボード非表示、入力欄タップでキーボード表示を確認

---

## 影響範囲

- **index.html**: サービスカード間隔、チャットボット入力制御
- **assets/css/chatbot.css**: モバイル版チャットボットレイアウト修正 (全ページ適用)

---

## 前提

- PR #27, #28の改善内容を含む
- モバイルパーティクル改善済み
