### PR TITLE
Fix: ブラウザtheme-color統一（白色）

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -15,8 +15,8 @@
     <meta name="keywords" content="AIエージェント開発, RAG構築, 伴走型AI開発, 暗黙知データ化, 技能継承, AI受託開発, ShinAI, LLM最適化, ベクトルデータベース, AI業務効率化, 生成AI導入, AI戦略コンサルティング, DX推進, 共創ビジネス, AIシステム構築, エンタープライズAI">
     <meta name="robots" content="index, follow, max-image-preview:large, max-snippet:-1, max-video-preview:-1">
     <meta name="author" content="ShinAI - AI System Development Company">
-    <meta name="theme-color" content="#3A5FEB">
-    <meta name="msapplication-TileColor" content="#3A5FEB">
+    <meta name="theme-color" content="#ffffff">
+    <meta name="msapplication-TileColor" content="#ffffff">
     <meta name="apple-mobile-web-app-capable" content="yes">
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
     

--- a/faq.html
+++ b/faq.html
@@ -10,8 +10,8 @@
     <meta name="keywords" content="AI FAQ, よくある質問, AI相談, AIエージェント, RAG構築, プロトタイプ開発, 伴走型開発, 生成AI, LLM, DX推進">
     <meta name="robots" content="index, follow">
     <meta name="author" content="ShinAI">
-    <meta name="theme-color" content="#3A5FEB">
-    <meta name="msapplication-TileColor" content="#3A5FEB">
+    <meta name="theme-color" content="#ffffff">
+    <meta name="msapplication-TileColor" content="#ffffff">
     <meta name="apple-mobile-web-app-capable" content="yes">
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
     

--- a/industries.html
+++ b/industries.html
@@ -15,8 +15,8 @@
     <meta name="keywords" content="AI活用事例, 業界別AI, AIエージェント開発, RAG構築, 福祉AI, 教育AI, 建設AI, 製造業AI, 小売AI, 金融AI, AI導入事例, ビジネスAI, 業務効率化, ShinAI">
     <meta name="robots" content="index, follow, max-image-preview:large, max-snippet:-1, max-video-preview:-1">
     <meta name="author" content="ShinAI - AI System Development Company">
-    <meta name="theme-color" content="#3A5FEB">
-    <meta name="msapplication-TileColor" content="#3A5FEB">
+    <meta name="theme-color" content="#ffffff">
+    <meta name="msapplication-TileColor" content="#ffffff">
     <meta name="apple-mobile-web-app-capable" content="yes">
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
     


### PR DESCRIPTION
## 修正内容

industries.html / faq.html / contact.html の3ページ、PC版ブラウザ上部（アドレスバー周辺）がブルー表示される問題を修正。

---

## 問題

3ページのみ `<meta name="theme-color" content="#3A5FEB">` （ブルー）に設定されていた。

---

## 修正

```html
<!-- 修正前 -->
<meta name="theme-color" content="#3A5FEB">
<meta name="msapplication-TileColor" content="#3A5FEB">

<!-- 修正後 -->
<meta name="theme-color" content="#ffffff">
<meta name="msapplication-TileColor" content="#ffffff">
```

---

## 影響

- PC版ブラウザ上部が白色表示
- モバイル版ステータスバーも白色統一
- 全6ページで一貫したブランド体験実現

---

## 変更ファイル

- industries.html (line 18-19)
- faq.html (line 13-14)
- contact.html (line 18-19)

---

Generated with Claude Code (Application-Layer AGI v12.0)

Co-Authored-By: Claude <noreply@anthropic.com>