### PR TITLE
feat: Add GitHub Actions auto-sync workflow for GitHub Pages deployment

### DIFF
--- a/project/website-main/.github/workflows/sync-to-root.yml
+++ b/project/website-main/.github/workflows/sync-to-root.yml
@@ -1,0 +1,76 @@
+name: Sync project/website-main to Repository Root
+
+on:
+  push:
+    branches:
+      - main
+      - gh-pages
+    paths:
+      - 'project/website-main/**'
+  workflow_dispatch:
+
+jobs:
+  sync-to-root:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Configure Git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Sync files from project/website-main to root
+        run: |
+          # Copy HTML files
+          cp -f project/website-main/*.html ./ || true
+
+          # Copy directories (api, assets)
+          cp -rf project/website-main/api ./api || true
+          cp -rf project/website-main/assets ./assets || true
+
+          # Copy .gitignore from project/website-main
+          cp -f project/website-main/.gitignore ./.gitignore || true
+
+      - name: Check for changes
+        id: check_changes
+        run: |
+          git add -A
+          if git diff --staged --quiet; then
+            echo "has_changes=false" >> $GITHUB_OUTPUT
+            echo "No changes to commit"
+          else
+            echo "has_changes=true" >> $GITHUB_OUTPUT
+            echo "Changes detected"
+          fi
+
+      - name: Commit and push changes
+        if: steps.check_changes.outputs.has_changes == 'true'
+        run: |
+          git commit -m "🤖 Auto-sync: project/website-main → repository root
+
+          Automated synchronization from project/website-main/ to repository root for GitHub Pages deployment.
+
+          Changes synced:
+          - HTML files (index.html, about.html, etc.)
+          - api/ directory
+          - assets/ directory
+          - .gitignore
+
+          🔗 Source: project/website-main/
+          🎯 Target: Repository root (GitHub Pages)"
+
+          git push origin ${{ github.ref_name }}
+
+      - name: Summary
+        if: steps.check_changes.outputs.has_changes == 'true'
+        run: |
+          echo "✅ Successfully synced project/website-main/ to repository root"
+          echo "📄 Files synced:"
+          git show --stat --oneline HEAD


### PR DESCRIPTION
## 概要
`project/website-main/` の変更を自動的にリポジトリルートに同期するGitHub Actionsワークフローを追加しました。

## 背景・課題
- GitHub Pagesはリポジトリルート (`/`) または `/docs` からのみ配信可能
- 現在は `project/website-main/` 内で開発しているが、公開サイトに反映されない
- 親ディレクトリを手動更新すると整合性の問題や技術的負債が発生

## 解決策
自動同期ワークフロー (`sync-to-root.yml`) を実装：
- `project/website-main/**` への変更を検知
- リポジトリルートに自動コピー
- GitHub Pagesへ即座反映

## 同期対象ファイル
- ✅ HTMLファイル (`*.html`)
- ✅ `api/` ディレクトリ
- ✅ `assets/` ディレクトリ  
- ✅ `.gitignore`

## トリガー条件
- `main` または `gh-pages` ブランチへの `project/website-main/**` 変更push
- 手動実行 (workflow_dispatch)

## 利点
- ✅ **開発効率向上**: `project/website-main/` 内のみで作業完結
- ✅ **整合性保証**: 自動同期で人的ミス防止
- ✅ **技術的負債ゼロ**: 親ディレクトリの手動操作不要
- ✅ **即座反映**: PR承認→マージ→自動同期→GitHub Pages更新

## 変更内容
### 追加ファイル
- `project/website-main/.github/workflows/sync-to-root.yml`

### チェックリスト
- ✅ `project/website-main/` 内のみの変更
- ✅ 親ディレクトリファイル未含
- ✅ 機密情報なし (.env, .key, .db等)
- ✅ 競合なし（リモート最新状態から作成）

## テスト方法
1. このPRをマージ
2. `project/website-main/` 内のHTMLファイルを修正
3. mainブランチにpush
4. GitHub Actionsでワークフローが自動実行されることを確認
5. リポジトリルートのファイルが更新されることを確認
6. GitHub Pagesが最新版を配信することを確認

## 注意事項
- このワークフローは `contents: write` 権限を使用します
- リポジトリルートへの自動コミットが発生します（`github-actions[bot]` による）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>