### PR TITLE
fix: Update chatbot.js cache busting to v4.0 - Fix ERR_BLOCKED_BY_CLIENT

### DIFF
--- a/project/website-main/about.html
+++ b/project/website-main/about.html
@@ -3234,6 +3234,6 @@
         window.CHATBOT_API_URL = 'https://api-massaa39s-projects.vercel.app';
     </script>
 
-    <script src="assets/js/chatbot.js?v=3.0"></script>
+    <script src="assets/js/chatbot.js?v=4.0"></script>
 </body>
 </html>

--- a/project/website-main/faq.html
+++ b/project/website-main/faq.html
@@ -2923,6 +2923,6 @@
         window.CHATBOT_API_URL = 'https://api-massaa39s-projects.vercel.app';
     </script>
 
-    <script src="assets/js/chatbot.js?v=3.0"></script>
+    <script src="assets/js/chatbot.js?v=4.0"></script>
 </body>
 </html>

--- a/project/website-main/index.html
+++ b/project/website-main/index.html
@@ -3176,6 +3176,6 @@
     </script>
 
     <!-- Chatbot JavaScript Component -->
-    <script src="assets/js/chatbot.js?v=3.0"></script>
+    <script src="assets/js/chatbot.js?v=4.0"></script>
 </body>
 </html>

--- a/project/website-main/industries.html
+++ b/project/website-main/industries.html
@@ -3840,6 +3840,6 @@
         window.CHATBOT_API_URL = 'https://api-massaa39s-projects.vercel.app';
     </script>
 
-    <script src="assets/js/chatbot.js?v=3.0"></script>
+    <script src="assets/js/chatbot.js?v=4.0"></script>
 </body>
 </html>

--- a/project/website-main/services.html
+++ b/project/website-main/services.html
@@ -2698,6 +2698,6 @@
         window.CHATBOT_API_URL = 'https://api-massaa39s-projects.vercel.app';
     </script>
 
-    <script src="assets/js/chatbot.js?v=3.0"></script>
+    <script src="assets/js/chatbot.js?v=4.0"></script>
 </body>
 </html>


### PR DESCRIPTION
## 問題
PR #51, #52でCHATBOT_API_URLを正しく設定したが、チャットボットがERR_BLOCKED_BY_CLIENTエラーを継続。

### エラー詳細
```
POST http://localhost:3001/api/chatbot net::ERR_BLOCKED_BY_CLIENT
[ShinAI Chatbot] エラー: TypeError: Failed to fetch
```

### 根本原因
ブラウザが古いキャッシュ(v3.0)を使用し、CHATBOT_API_URL設定が反映されていない。

## 解決策
キャッシュバスティングバージョン更新：`v=3.0` → `v=4.0`

## 変更ファイル（project/website-main/内のみ）
- about.html
- faq.html
- index.html
- industries.html
- services.html

## チェックリスト
- ✅ project/website-main/内のみ変更
- ✅ 親ディレクトリファイル未含
- ✅ 機密情報なし
- ✅ 競合なし

## 期待される効果
- ✅ ブラウザキャッシュクリア
- ✅ Vercel API正常接続
- ✅ ERR_BLOCKED_BY_CLIENTエラー解消

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>