### PR TITLE
fix: モバイル版チャットボットの送信ボタン重複問題を修正

### DIFF
--- a/project/website-main/assets/css/chatbot.css
+++ b/project/website-main/assets/css/chatbot.css
@@ -449,6 +449,13 @@ AUTHOR: ShinAI Development Team
         font-size: 1.2rem;
     }
 
+    /* モバイル版: チャットウィンドウが開いている時は開閉ボタンを非表示（送信ボタンとの重複防止） */
+    .chatbot-window.active ~ .chatbot-button {
+        display: none !important;
+        visibility: hidden !important;
+        pointer-events: none !important;
+    }
+
     /* モバイル版チャットボット最適化 - キーボード表示時の対応強化 */
     .chatbot-window {
         position: fixed !important;


### PR DESCRIPTION
## 問題

services.htmlのモバイル版で、チャットボットウィンドウを開いた時に、**送信ボタン（chat-send）と既存のチャットボット開閉ボタン（chatbot-button）が重なって表示され、送信ができない**問題が発生していました。

## 解決方法

モバイル版CSSに以下のルールを追加し、チャットウィンドウが開いている時はチャットボット開閉ボタンを完全に非表示にしました：

```css
/* モバイル版: チャットウィンドウが開いている時は開閉ボタンを非表示（送信ボタンとの重複防止） */
.chatbot-window.active ~ .chatbot-button {
    display: none !important;
    visibility: hidden !important;
    pointer-events: none !important;
}
```

## 変更内容

- ✅ **ファイル**: `assets/css/chatbot.css`
- ✅ **対象**: モバイル版のみ（`@media (max-width: 768px)`）
- ✅ **効果**: チャットウィンドウが開いている時、開閉ボタンを完全に非表示
- ✅ **動作**: `display: none` + `visibility: hidden` + `pointer-events: none`で確実に操作不能

## ユーザー体験の改善

### 修正前
❌ モバイルでチャットウィンドウを開くと、送信ボタンとチャットボット開閉ボタンが重なり、送信できない

### 修正後
✅ チャットウィンドウを開くと、チャットボット開閉ボタンが非表示になり、送信ボタンが確実にタップ可能

## 安全性確認

✅ **親ディレクトリファイル**: 一切含まれていない  
✅ **機密情報**: なし（CSSのみの変更）  
✅ **変更ファイル**: `project/website-main/assets/css/chatbot.css` のみ  
✅ **マージ競合**: なし（最新のgh-pagesから作成）

## テスト

- モバイル版（768px以下）でチャットボットを開いた時、開閉ボタンが非表示になることを確認
- デスクトップ版では従来通り動作することを確認
- 送信ボタンが確実にタップ可能になることを確認

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)