### PR TITLE
fix: チャットボットヘッダー視認性と業界カードタップ誤解を改善

### DIFF
--- a/project/website-main/assets/css/chatbot.css
+++ b/project/website-main/assets/css/chatbot.css
@@ -486,14 +486,20 @@ AUTHOR: ShinAI Development Team
     }
 
     .chatbot-header {
-        padding: 1rem 1.2rem;
+        padding: 0.75rem 1rem;
         border-radius: 0;
         flex-shrink: 0;
+        min-height: 50px;
+        box-sizing: border-box;
     }
 
     .chatbot-header h3 {
-        font-size: 0.95rem;
-        gap: 0.6rem;
+        font-size: 1rem;
+        gap: 0.5rem;
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        flex: 1;
     }
 
     .chatbot-close {
@@ -503,24 +509,24 @@ AUTHOR: ShinAI Development Team
     }
 
     .chatbot-messages {
-        padding: 1rem !important; /* 均等なパディング */
+        padding: 0.75rem 1rem !important;
         gap: 0.75rem;
         flex: 1 1 auto !important;
         overflow-y: auto !important;
         overflow-x: hidden !important;
-        -webkit-overflow-scrolling: touch; /* iOSでスムーズスクロール */
-        min-height: 0 !important;
+        -webkit-overflow-scrolling: touch;
+        min-height: 150px !important;
         width: 100% !important;
-        max-width: 100vw !important; /* ビューポート幅を超えない */
+        max-width: 100vw !important;
         box-sizing: border-box !important;
     }
 
     .chatbot-input {
         display: flex !important;
         align-items: center !important;
-        gap: 0.5rem !important; /* margin-leftの代わりにgapを使用 */
-        padding: 0.75rem !important; /* パディングを少し減らして余裕を確保 */
-        padding-bottom: calc(0.75rem + env(safe-area-inset-bottom)) !important;
+        gap: 0.5rem !important;
+        padding: 0.65rem 1rem !important;
+        padding-bottom: calc(0.65rem + env(safe-area-inset-bottom)) !important;
         background: var(--white);
         position: sticky !important;
         bottom: 0 !important;
@@ -528,9 +534,10 @@ AUTHOR: ShinAI Development Team
         border-top: 1px solid rgba(0, 0, 0, 0.05);
         flex-shrink: 0 !important;
         width: 100% !important;
-        max-width: 100vw !important; /* ビューポート幅を超えないように */
+        max-width: 100vw !important;
         box-sizing: border-box !important;
-        overflow: hidden !important; /* 横スクロール防止 */
+        overflow: hidden !important;
+        min-height: 60px;
     }
 
     .chatbot-input input {

--- a/project/website-main/industries.html
+++ b/project/website-main/industries.html
@@ -1449,7 +1449,20 @@
         box-shadow: 0 0 10px rgba(var(--finance-primary), 0.4);
     }
 
-    /* 
+    /* モバイル版: タップ時のアニメーションを無効化してリンク誤解を防止 */
+    @media (max-width: 768px) {
+        .industry-card:hover {
+            transform: none;
+            box-shadow: 0 4px 16px rgba(0, 0, 0, 0.04);
+            border-color: rgba(0, 0, 0, 0.05);
+        }
+
+        .industry-card:hover .industry-icon {
+            transform: none;
+        }
+    }
+
+    /*
     ==============================================
     // === component-split: SimplifiedIndustryFooter ===
     COMPONENT: 簡略化された業界カードフッター


### PR DESCRIPTION
## 改善内容

### チャットボット (chatbot.css)

**ヘッダー改善**
- パディング削減（0.75rem 1rem）
- min-height: 50px
- タイトル省略記号対応
- フォントサイズ1rem

**メッセージエリア**
- min-height: 150px（キーボード表示時も視認可能）
- パディング最適化

**入力エリア**
- パディング削減（0.65rem 1rem）
- min-height: 60px

### 業界別活用ページ (industries.html)

**モバイル版カード**
- タップ時アニメーション無効化
- リンク誤解防止

## セキュリティ確認

- ✅ `project/website-main/`のみ
- ✅ 機密情報なし
- ✅ 親ディレクトリ操作なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)