### PR TITLE
fix: モバイル版業界カードのタップエフェクトを完全無効化

### DIFF
--- a/project/website-main/industries.html
+++ b/project/website-main/industries.html
@@ -1451,14 +1451,23 @@
 
     /* モバイル版: タップ時のアニメーションを無効化してリンク誤解を防止 */
     @media (max-width: 768px) {
-        .industry-card:hover {
-            transform: none;
-            box-shadow: 0 4px 16px rgba(0, 0, 0, 0.04);
-            border-color: rgba(0, 0, 0, 0.05);
+        .industry-card:hover,
+        .industry-card:active,
+        .industry-card:focus {
+            transform: none !important;
+            box-shadow: 0 4px 16px rgba(0, 0, 0, 0.04) !important;
+            border-color: rgba(0, 0, 0, 0.05) !important;
         }
 
-        .industry-card:hover .industry-icon {
-            transform: none;
+        .industry-card:hover .industry-icon,
+        .industry-card:active .industry-icon,
+        .industry-card:focus .industry-icon {
+            transform: none !important;
+        }
+
+        .industry-card {
+            -webkit-tap-highlight-color: transparent;
+            touch-action: manipulation;
         }
     }
 


### PR DESCRIPTION
## 問題

モバイルでカードタップ時に浮き上がるエフェクトが発生し、
リンクと誤解される可能性がある。

## 解決策

### 全タップ状態で無効化
- `:hover` だけでなく `:active`、`:focus` も追加
- `!important` で確実に適用

### タップハイライト除去
- `-webkit-tap-highlight-color: transparent`
- `touch-action: manipulation`

### 効果
- カードが動かない
- タップハイライトなし
- リンク誤解を完全防止

## セキュリティ確認
- ✅ `project/website-main/`のみ
- ✅ 機密情報なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)