### PR TITLE
fix: Add GitHub Pages origin to CORS allowed origins

### DIFF
--- a/project/website-main/api/chatbot-api.js
+++ b/project/website-main/api/chatbot-api.js
@@ -69,6 +69,7 @@ const homepageRateLimiter = new HomepageRateLimiter();
 const allowedOrigins = process.env.FRONTEND_URL
     ? [process.env.FRONTEND_URL]
     : [
+        'https://shin-ai-inc.github.io',  // GitHub Pages (Production)
         'http://localhost:3000',
         'http://localhost:5500',
         'http://localhost:8080',  // Python HTTP Server


### PR DESCRIPTION
## Summary
- GitHub PagesのオリジンをCORS許可リストに追加
- Vercel APIへのアクセス時のCORSエラーを解決

## Problem
チャットボットがGitHub Pages上で動作しない問題が発生していました：

```
Access to fetch at 'https://api-5vi2knktj-massaa39s-projects.vercel.app/api/chatbot' 
from origin 'https://shin-ai-inc.github.io' has been blocked by CORS policy: 
Response to preflight request doesn't pass access control check: 
No 'Access-Control-Allow-Origin' header is present on the requested resource.
```

### Root Cause
`api/chatbot-api.js`のCORS設定で、GitHub Pagesのオリジン（`https://shin-ai-inc.github.io`）が許可リストに含まれていませんでした。

### Before (Lines 69-77)
```javascript
const allowedOrigins = process.env.FRONTEND_URL
    ? [process.env.FRONTEND_URL]
    : [
        'http://localhost:3000',
        'http://localhost:5500',
        'http://localhost:8080',  // Python HTTP Server
        'http://127.0.0.1:5500',
        'http://127.0.0.1:8080'
      ];
```

## Changes Made

### After (Lines 69-78)
```javascript
const allowedOrigins = process.env.FRONTEND_URL
    ? [process.env.FRONTEND_URL]
    : [
        'https://shin-ai-inc.github.io',  // GitHub Pages (Production)
        'http://localhost:3000',
        'http://localhost:5500',
        'http://localhost:8080',  // Python HTTP Server
        'http://127.0.0.1:5500',
        'http://127.0.0.1:8080'
      ];
```

## Impact
✅ GitHub Pages上でチャットボットが正常に動作するようになります  
✅ 既存のローカル開発環境には影響なし  
✅ セキュリティ要件を満たす（許可されたオリジンのみ）

## Testing Plan
1. Vercelへデプロイ
2. https://shin-ai-inc.github.io/website/index.html でチャットボットをテスト
3. ブラウザコンソールでCORSヘッダーを確認
4. API応答が正常に受信されることを確認

## Security Compliance
- ✅ `project/website-main/` 内のみ修正
- ✅ 機密情報なし
- ✅ 親ディレクトリ操作なし
- ✅ 安全なpush -u使用

🤖 Generated with [Claude Code](https://claude.com/claude-code)