### PR TITLE
fix: Correct Vercel routing to support all paths

### DIFF
--- a/project/website-main/api/vercel.json
+++ b/project/website-main/api/vercel.json
@@ -8,11 +8,7 @@
   ],
   "routes": [
     {
-      "src": "/api/chatbot/health",
-      "dest": "/chatbot-api.js"
-    },
-    {
-      "src": "/api/chatbot",
+      "src": "/(.*)",
       "dest": "/chatbot-api.js"
     }
   ]


### PR DESCRIPTION
## 問題 (Problem)

Vercel APIが404エラーを返していました：
- https://api-5vi2knktj-massaa39s-projects.vercel.app/api/chatbot/health → 404
- https://api-5vi2knktj-massaa39s-projects.vercel.app/api/chatbot → 404

これにより、GitHub Pagesのチャットボットが正常に動作せず、エラーメッセージが表示されていました。

## 根本原因 (Root Cause)

`api/vercel.json`のルーティング設定が不完全でした。

`chatbot-api.js`はExpressアプリケーションで、内部で`/api/chatbot`、`/api/chatbot/health`などのルートを定義しています。しかし、`vercel.json`で個別のパスを指定していたため、Vercelがこれらのパスを正しくExpressアプリにルーティングできていませんでした。

### 問題のあった設定
```json
"routes": [
  {
    "src": "/api/chatbot/health",
    "dest": "/chatbot-api.js"
  },
  {
    "src": "/api/chatbot",
    "dest": "/chatbot-api.js"
  }
]
```

この設定では、Expressアプリ内のルーティングロジックが正しく機能しませんでした。

## 解決策 (Solution)

すべてのパスを`chatbot-api.js`にルーティングする**キャッチオールルート**に変更しました：

```json
"routes": [
  {
    "src": "/(.*)",
    "dest": "/chatbot-api.js"
  }
]
```

これにより、Expressアプリケーションがすべてのリクエストを受け取り、内部で定義されたルーティングロジック（`app.get('/api/chatbot/health')`、`app.post('/api/chatbot')`など）が正常に動作するようになります。

## 変更内容 (Changes)

- `api/vercel.json`: ルーティング設定を個別パス指定からキャッチオールパターンに変更

## 期待される結果 (Expected Results)

✅ `/api/chatbot/health` → 200 OK（ヘルスチェック成功）  
✅ `/api/chatbot` → POST可能（チャットボットメッセージ処理）  
✅ GitHub Pagesのチャットボットが正常に応答  

## テスト方法 (Testing)

PR マージ後、以下を確認してください：

1. **Vercel API動作確認**:
   ```bash
   curl https://api-5vi2knktj-massaa39s-projects.vercel.app/api/chatbot/health
   ```
   期待: `{"status":"ok","timestamp":"...","service":"chatbot-api"}`

2. **GitHub Pages チャットボット確認**:
   - https://shin-ai-inc.github.io/website/index.html
   - チャットボットで「こんにちは」と入力
   - 期待: 適切な応答が返る（エラーメッセージではない）

## 関連PR (Related PRs)

- PR #89: `vercel.json`の初期作成（ルーティング設定が不完全だった）
- PR #85: CORS設定にGitHub Pages originを追加

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)