### PR TITLE
fix: Remove leading slash from vercel.json dest path

### DIFF
--- a/project/website-main/api/vercel.json
+++ b/project/website-main/api/vercel.json
@@ -9,7 +9,7 @@
   "routes": [
     {
       "src": "/(.*)",
-      "dest": "/chatbot-api.js"
+      "dest": "chatbot-api.js"
     }
   ]
 }


### PR DESCRIPTION
## 問題 (Problem)

Vercel APIが404エラーを返し続けています：
- https://api-massaa39s-projects.vercel.app/api/chatbot/health → 404  
- https://api-massaa39s-projects.vercel.app/api/chatbot → 404

`vercel inspect`で確認したところ、デプロイ自体は成功しており、`chatbot-api.js`（618.5KB）がビルドされていますが、ルーティングが機能していません。

## 根本原因 (Root Cause)

`api/vercel.json`の`routes`設定で、`dest`に**先頭スラッシュ付き**の`"/chatbot-api.js"`を指定していました。

Vercelのドキュメントによると、`dest`パスは**相対パス**で指定する必要があります。先頭スラッシュがあると、Vercelはこれをルートディレクトリからの絶対パスと解釈し、正しくルーティングできません。

### 問題のあった設定
```json
"routes": [
  {
    "src": "/(.*)",
    "dest": "/chatbot-api.js"  // ← 先頭スラッシュが問題
  }
]
```

## 解決策 (Solution)

`dest`パスから先頭スラッシュを削除し、相対パスに修正しました：

```json
"routes": [
  {
    "src": "/(.*)",
    "dest": "chatbot-api.js"  // ← 相対パス（正しい）
  }
]
```

## 変更内容 (Changes)

- `api/vercel.json`: `dest`パスを絶対パスから相対パスに修正

## 期待される結果 (Expected Results)

✅ `/api/chatbot/health` → 200 OK  
✅ `/api/chatbot` → POST可能  
✅ GitHub Pagesのチャットボットが正常動作  

## テスト手順 (Testing Steps)

PR マージ後、Vercelが自動デプロイされたら：

1. **ヘルスチェック確認**:
   ```bash
   curl https://api-massaa39s-projects.vercel.app/api/chatbot/health
   ```
   期待: `{"status":"ok","timestamp":"...","service":"chatbot-api"}`

2. **チャットボットメッセージ送信テスト**:
   ```bash
   curl -X POST https://api-massaa39s-projects.vercel.app/api/chatbot \
     -H "Content-Type: application/json" \
     -d '{"message":"こんにちは","sessionId":"test123"}'
   ```
   期待: `{"success":true,"response":"...","sessionId":"test123"}`

3. **GitHub Pages確認**:
   - https://shin-ai-inc.github.io/website/index.html
   - チャットボットで「こんにちは」と入力
   - 期待: 適切な応答（エラーではない）

## 参考資料 (References)

- [Vercel Configuration - Routes](https://vercel.com/docs/projects/project-configuration#routes)
- [Vercel Serverless Functions](https://vercel.com/docs/functions/serverless-functions)

## 関連PR (Related PRs)

- PR #90: Catch-all routing追加（先頭スラッシュ問題が残っていた）
- PR #89: vercel.json初期作成

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)