### PR TITLE
fix: Update chatbot API URL to Vercel production alias

### DIFF
--- a/project/website-main/index.html
+++ b/project/website-main/index.html
@@ -3169,11 +3169,11 @@
     <!-- API Configuration - 本番環境設定 -->
     <script>
         // Chatbot API Endpoint Configuration
-        // Vercel固定ドメインURL（デプロイごとに変わらない永続URL）
-        window.CHATBOT_API_URL = 'https://api-5vi2knktj-massaa39s-projects.vercel.app';
+        // Vercel Production Alias URL（プロダクション環境の永続URL）
+        window.CHATBOT_API_URL = 'https://api-massaa39s-projects.vercel.app';
     </script>
 
     <!-- Chatbot JavaScript Component -->
-    <script src="assets/js/chatbot.js?v=4.2"></script>
+    <script src="assets/js/chatbot.js?v=4.4"></script>
 </body>
 </html>


### PR DESCRIPTION
## 問題 (Problem)

チャットボットが404エラーを表示していました：

**旧API URL**: `https://api-5vi2knktj-massaa39s-projects.vercel.app`  
→ このURLは4時間前の古いデプロイメントを指しており、現在は動作していません

## 根本原因 (Root Cause)

`index.html`で指定していたAPI URLが、**固定デプロイメントURL**（特定のデプロイメントを指すURL）でした。Vercelでは、新しいデプロイメントが作成されるたびに、固定デプロイメントURLは変わります。

そのため、PR #90、#91をマージして新しいデプロイメントが作成された後、古いURLは無効になりました。

## 解決策 (Solution)

**Vercel Production Alias URL**に更新しました：

**新API URL**: `https://api-massaa39s-projects.vercel.app`  
→ このURLは常に最新のプロダクションデプロイメントを自動的に指します

### メリット
- ✅ 新しいデプロイメント後も自動的に最新版を参照
- ✅ 手動でURLを更新する必要がない
- ✅ プロダクション環境の永続URL

## 変更内容 (Changes)

1. **API URL更新** (`index.html:3173`):
   ```diff
   - window.CHATBOT_API_URL = 'https://api-5vi2knktj-massaa39s-projects.vercel.app';
   + window.CHATBOT_API_URL = 'https://api-massaa39s-projects.vercel.app';
   ```

2. **キャッシュバスティング更新** (`index.html:3177`):
   ```diff
   - <script src="assets/js/chatbot.js?v=4.2"></script>
   + <script src="assets/js/chatbot.js?v=4.4"></script>
   ```

## 検証済み (Verified)

✅ **API Health Check**:
```bash
curl https://api-massaa39s-projects.vercel.app/api/chatbot/health
```
Response: `{"status":"ok","timestamp":"2025-12-09T07:46:19.870Z","service":"chatbot-api"}`

✅ **API動作確認**: Vercel APIは正常に動作しています

## 期待される結果 (Expected Results)

PR マージ → gh-pages同期後：

✅ https://shin-ai-inc.github.io/website/index.html のチャットボットが正常動作  
✅ 「こんにちは」と入力 → 適切な応答が返る  
✅ エラーメッセージが表示されない  

## テスト手順 (Testing Steps)

PR マージ後、gh-pagesブランチに同期してから：

1. https://shin-ai-inc.github.io/website/index.html にアクセス
2. チャットボットアイコンをクリック
3. 「こんにちは」と入力して送信
4. 期待: 適切な応答（例: "こんにちは！本日はご訪問いただきありがとうございます..."）

## 関連PR (Related PRs)

- PR #91: vercel.json dest パスの修正（これによりVercel APIが動作可能に）
- PR #90: Catch-all routing追加
- PR #89: vercel.json初期作成

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)