### PR TITLE
fix: Add GitHub Pages deployment workflow

### DIFF
--- a/project/website-main/.github/workflows/deploy-pages.yml
+++ b/project/website-main/.github/workflows/deploy-pages.yml
@@ -1,0 +1,40 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches:
+      - gh-pages
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: gh-pages
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v4
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: '.'
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
## 問題 (Problem)

GitHub Pagesが最新のgh-pagesブランチの内容を配信していません：

**gh-pagesブランチ**:
- ✅ API URL: `https://api-massaa39s-projects.vercel.app`（最新）
- ✅ Version: `v=4.4`（最新）
- ✅ コミット: `6c0bd6e`（今日プッシュ済み）

**公開サイト**:
- ❌ API URL: `https://api-5vi2knktj-massaa39s-projects.vercel.app`（古い）
- ❌ Version: `v=4.0`（古い）
- ❌ 最後のビルド: `2025-12-08 11:44`（昨日）

## 根本原因 (Root Cause)

GitHub Pages設定が`"build_type": "workflow"`になっていますが、適切なデプロイメントワークフローが存在していませんでした。

既存の`sync-to-root.yml`はファイル同期用で、GitHub Pagesへのデプロイ機能は含まれていません。そのため、gh-pagesブランチにプッシュしても、GitHub Pagesが更新されませんでした。

## 解決策 (Solution)

GitHub公式の`actions/deploy-pages`を使用したデプロイメントワークフローを追加しました：

### 新規ファイル: `.github/workflows/deploy-pages.yml`

**主な機能**:
- ✅ gh-pagesブランチへのpushで自動デプロイ
- ✅ 手動トリガー（`workflow_dispatch`）も可能
- ✅ 適切なpermissions設定（`pages: write`, `id-token: write`）
- ✅ concurrency制御でビルドの衝突を防止

**ワークフロー構成**:
```yaml
1. Checkout gh-pages branch
2. Setup GitHub Pages
3. Upload artifact (全ファイル)
4. Deploy to GitHub Pages
```

## 期待される結果 (Expected Results)

✅ gh-pagesブランチにプッシュ → 自動的にGitHub Pagesデプロイ  
✅ 公開サイトが最新コンテンツを配信（v=4.4, 新API URL）  
✅ チャットボットが正常に動作  

## テスト手順 (Testing Steps)

PR マージ後：

1. **ワークフロー実行確認**:
   - GitHub Actions タブで`Deploy to GitHub Pages`ワークフローが実行されることを確認

2. **公開サイト確認**（デプロイ完了後）:
   ```bash
   curl https://shin-ai-inc.github.io/website/index.html | grep "CHATBOT_API_URL"
   ```
   期待: `https://api-massaa39s-projects.vercel.app`

3. **チャットボット動作確認**:
   - https://shin-ai-inc.github.io/website/index.html
   - チャットボットで「こんにちは」と入力
   - 期待: 適切な応答（RAGシステムからの返答）

## 参考資料 (References)

- [GitHub Pages deployment action](https://github.com/actions/deploy-pages)
- [Configuring Pages](https://github.com/actions/configure-pages)
- [Upload Pages artifact](https://github.com/actions/upload-pages-artifact)

## 関連PR (Related PRs)

- PR #92: API URLをプロダクションエイリアスに更新
- PR #91: vercel.json destパス修正
- PR #90: Catch-all routing追加

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)