### PR TITLE
fix: Sync .github directory to repository root

### DIFF
--- a/project/website-main/.github/workflows/sync-to-root.yml
+++ b/project/website-main/.github/workflows/sync-to-root.yml
@@ -31,9 +31,10 @@ jobs:
           # Copy HTML files
           cp -f project/website-main/*.html ./ || true
 
-          # Copy directories (api, assets)
+          # Copy directories (api, assets, .github)
           cp -rf project/website-main/api ./api || true
           cp -rf project/website-main/assets ./assets || true
+          cp -rf project/website-main/.github ./.github || true
 
           # Copy .gitignore from project/website-main
           cp -f project/website-main/.gitignore ./.gitignore || true
@@ -61,6 +62,7 @@ jobs:
           - HTML files (index.html, about.html, etc.)
           - api/ directory
           - assets/ directory
+          - .github/ directory (workflows)
           - .gitignore
 
           🔗 Source: project/website-main/


### PR DESCRIPTION
## 問題 (Problem)

GitHub Actionsが`deploy-pages.yml`ワークフローを認識せず、GitHub Pagesが更新されていません。

**現状**:
- ワークフローファイル: `project/website-main/.github/workflows/deploy-pages.yml`
- GitHub Actionsの要求: リポジトリルートの`.github/workflows/`

GitHubは**リポジトリルートの`.github/workflows/`にあるワークフローのみ**を認識します。

## 根本原因 (Root Cause)

`sync-to-root.yml`ワークフローは、`api/`、`assets/`、`*.html`をルートにコピーしていましたが、**`.github`ディレクトリはコピーしていませんでした**。

そのため、`deploy-pages.yml`がリポジトリルートに存在せず、GitHub Actionsが認識できませんでした。

## 解決策 (Solution)

`sync-to-root.yml`を修正して、`.github`ディレクトリもリポジトリルートにコピーするようにしました：

### 変更内容

```diff
  # Copy directories (api, assets)
  cp -rf project/website-main/api ./api || true
  cp -rf project/website-main/assets ./assets || true
+ cp -rf project/website-main/.github ./.github || true
```

これにより、`project/website-main/.github/workflows/deploy-pages.yml`が自動的に`.github/workflows/deploy-pages.yml`にコピーされます。

## 期待される結果 (Expected Results)

✅ このPRマージ → sync-to-root.ymlが`.github`をコピー  
✅ `.github/workflows/deploy-pages.yml`がリポジトリルートに配置  
✅ GitHub Actionsがワークフローを認識  
✅ gh-pagesブランチへのpush → 自動デプロイトリガー  
✅ GitHub Pagesが最新コンテンツ（v=4.4, 新API URL）を配信  
✅ チャットボットが正常動作  

## テスト手順 (Testing Steps)

PR マージ後：

1. **sync-to-rootワークフローが実行されることを確認**:
   ```bash
   gh run list --workflow=sync-to-root.yml --limit 1
   ```

2. **リポジトリルートに.githubがコピーされたことを確認**:
   ```bash
   gh api repos/:owner/:repo/contents/.github/workflows/deploy-pages.yml
   ```

3. **deploy-pagesワークフローが認識されたことを確認**:
   ```bash
   gh workflow list | grep "Deploy to GitHub Pages"
   ```

4. **公開サイトが最新になったことを確認**:
   - https://shin-ai-inc.github.io/website/index.html
   - 開発者ツール → Console → `window.CHATBOT_API_URL`を確認
   - 期待: `https://api-massaa39s-projects.vercel.app`

5. **チャットボット動作確認**:
   - 「こんにちは」と入力
   - 期待: 適切な応答（RAGシステムからの返答）

## 関連PR (Related PRs)

- PR #93: GitHub Pages deployment workflow追加
- PR #92: API URLをプロダクションエイリアスに更新
- PR #91: vercel.json destパス修正

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)