### PR TITLE
fix: Critical chatbot API URL configuration fix

### DIFF
--- a/assets/js/chatbot.js
+++ b/assets/js/chatbot.js
@@ -197,7 +197,12 @@ const ShinAIChatbot = {
             }
 
             // API呼び出し
-            const apiResponse = await fetch('http://localhost:3001/api/chatbot', {
+            // 環境に応じたAPI URLを使用 (index.htmlで設定)
+            const apiUrl = window.CHATBOT_API_URL
+                ? `${window.CHATBOT_API_URL}/api/chatbot`
+                : 'http://localhost:3001/api/chatbot'; // Fallback for local dev
+
+            const apiResponse = await fetch(apiUrl, {
                 method: 'POST',
                 headers: {
                     'Content-Type': 'application/json'

--- a/index.html
+++ b/index.html
@@ -3174,7 +3174,7 @@
     </script>
 
     <!-- Chatbot JavaScript Component -->
-    <script src="assets/js/chatbot.js?v=4.4"></script>
+    <script src="assets/js/chatbot.js?v=4.5"></script>
 </body>
 </html>
 <!-- Trigger sync workflow -->


### PR DESCRIPTION
## 概要 (Summary)

チャットボットがlocalhost URLにハードコードされていた問題を修正しました。これにより、公開サイトでチャットボットが正常に動作するようになります。

## 問題 (Problem)

**根本原因**: 
- `chatbot.js` line 200で`http://localhost:3001/api/chatbot`にハードコード
- `window.CHATBOT_API_URL`の設定が完全に無視されていた
- 結果: 公開サイトで`ERR_BLOCKED_BY_CLIENT`エラー発生

**ユーザーへの影響**:
```
POST http://localhost:3001/api/chatbot net::ERR_BLOCKED_BY_CLIENT
chatbot.js?v=4.4:228 [ShinAI Chatbot] エラー: TypeError: Failed to fetch
```

## 解決策 (Solution)

### 修正内容

**1. chatbot.js (assets/js/chatbot.js:199-214)**
```javascript
// 修正前
const apiResponse = await fetch('http://localhost:3001/api/chatbot', {

// 修正後
const apiUrl = window.CHATBOT_API_URL
    ? `${window.CHATBOT_API_URL}/api/chatbot`
    : 'http://localhost:3001/api/chatbot'; // Fallback for local dev

const apiResponse = await fetch(apiUrl, {
```

**2. index.html (line 3177)**
```diff
- <script src="assets/js/chatbot.js?v=4.4"></script>
+ <script src="assets/js/chatbot.js?v=4.5"></script>
```

## 変更ファイル (Changed Files)

- `assets/js/chatbot.js`: API URL設定を環境変数から読み込むように修正
- `index.html`: キャッシュバスティング v=4.4 → v=4.5

## 技術的詳細 (Technical Details)

### 動作フロー
1. `index.html`が`window.CHATBOT_API_URL`を設定
2. `chatbot.js`が環境に応じて適切なURLを使用:
   - 本番: `https://api-massaa39s-projects.vercel.app/api/chatbot`
   - 開発: `http://localhost:3001/api/chatbot` (fallback)

### 期待される結果
✅ 公開サイト: Vercel APIに正常接続  
✅ ローカル開発: localhost APIに正常接続（fallback）  
✅ エラー解消: ERR_BLOCKED_BY_CLIENT完全解決  
✅ RAGシステム: 本番環境で正常動作  

## セキュリティ確認 (Security Check)

✅ 機密情報なし  
✅ 親ディレクトリファイル除外  
✅ 安全なコミット履歴  

## テスト手順 (Testing)

PR マージ後：

1. https://shin-ai-inc.github.io/website/ にアクセス
2. チャットボットを開く
3. 「こんにちは」と送信
4. **期待**: RAGシステムからの適切な応答
5. **確認**: コンソールエラーなし

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>